### PR TITLE
Support prompt batching and enrich model metadata

### DIFF
--- a/app/routers/completions.py
+++ b/app/routers/completions.py
@@ -32,104 +32,118 @@ async def create_completion(payload: CompletionRequest):
         get_model_spec(payload.model)
     except KeyError:
         raise model_not_found(payload.model)
-    prompt = payload.prompt if isinstance(payload.prompt, str) else "\n".join(payload.prompt)
+    prompts: List[str]
+    if isinstance(payload.prompt, str):
+        prompts = [payload.prompt]
+    else:
+        prompts = list(payload.prompt)
     stop_sequences = payload.stop if isinstance(payload.stop, list) else (
         [payload.stop] if payload.stop else []
     )
     if payload.stream:
-        return _streaming_completion(payload, prompt, stop_sequences)
-    try:
-        result = await asyncio.to_thread(
-            engine.generate,
-            payload.model,
-            prompt,
-            temperature=payload.temperature,
-            top_p=payload.top_p,
-            max_tokens=payload.max_tokens,
-            stop=stop_sequences,
-            n=payload.n,
-        )
-    except Exception as exc:  # pragma: no cover - bubble as OpenAI-style error
-        raise openai_http_error(
-            500,
-            f"Generation error: {exc}",
-            error_type="server_error",
-            code="generation_error",
-        )
+        return _streaming_completion(payload, prompts, stop_sequences)
     choices: List[CompletionChoice] = []
+    total_prompt_tokens = 0
     total_completion_tokens = 0
-    for index, item in enumerate(result.completions):
-        total_completion_tokens += item.tokens
-        choices.append(
-            CompletionChoice(
-                text=item.text,
-                index=index,
-                logprobs=None,
-                finish_reason=item.finish_reason,
-            )
-        )
-    usage = UsageInfo(
-        prompt_tokens=result.prompt_tokens,
-        completion_tokens=total_completion_tokens,
-        total_tokens=result.prompt_tokens + total_completion_tokens,
-    )
-    return CompletionResponse(model=payload.model, choices=choices, usage=usage)
-
-
-def _streaming_completion(
-    payload: CompletionRequest,
-    prompt: str,
-    stop_sequences: List[str],
-) -> StreamingResponse:
-    completion_id = f"cmpl-{uuid.uuid4().hex}"
-
-    def event_stream() -> Generator[bytes, None, None]:
-        total_completion_tokens = 0
-        prompt_tokens = None
-        for index in range(payload.n):
-            stream = engine.create_stream(
+    choice_index = 0
+    for prompt in prompts:
+        try:
+            result = await asyncio.to_thread(
+                engine.generate,
                 payload.model,
                 prompt,
                 temperature=payload.temperature,
                 top_p=payload.top_p,
                 max_tokens=payload.max_tokens,
                 stop=stop_sequences,
+                n=payload.n,
             )
-            if prompt_tokens is None:
-                prompt_tokens = stream.prompt_tokens
-            collected_text = ""
-            for token in stream.iter_tokens():
-                collected_text += token
-                chunk = CompletionChunk(
+        except Exception as exc:  # pragma: no cover - bubble as OpenAI-style error
+            raise openai_http_error(
+                500,
+                f"Generation error: {exc}",
+                error_type="server_error",
+                code="generation_error",
+            )
+        total_prompt_tokens += result.prompt_tokens
+        for item in result.completions:
+            total_completion_tokens += item.tokens
+            choices.append(
+                CompletionChoice(
+                    text=item.text,
+                    index=choice_index,
+                    logprobs=None,
+                    finish_reason=item.finish_reason,
+                )
+            )
+            choice_index += 1
+    usage = UsageInfo(
+        prompt_tokens=total_prompt_tokens,
+        completion_tokens=total_completion_tokens,
+        total_tokens=total_prompt_tokens + total_completion_tokens,
+    )
+    return CompletionResponse(model=payload.model, choices=choices, usage=usage)
+
+
+def _streaming_completion(
+    payload: CompletionRequest,
+    prompts: List[str],
+    stop_sequences: List[str],
+) -> StreamingResponse:
+    completion_id = f"cmpl-{uuid.uuid4().hex}"
+
+    def event_stream() -> Generator[bytes, None, None]:
+        total_completion_tokens = 0
+        aggregated_prompt_tokens = 0
+        choice_index = 0
+        for prompt in prompts:
+            prompt_token_count_recorded = False
+            for _ in range(payload.n):
+                stream = engine.create_stream(
+                    payload.model,
+                    prompt,
+                    temperature=payload.temperature,
+                    top_p=payload.top_p,
+                    max_tokens=payload.max_tokens,
+                    stop=stop_sequences,
+                )
+                if not prompt_token_count_recorded:
+                    aggregated_prompt_tokens += stream.prompt_tokens
+                    prompt_token_count_recorded = True
+                collected_text = ""
+                for token in stream.iter_tokens():
+                    collected_text += token
+                    chunk = CompletionChunk(
+                        id=completion_id,
+                        created=int(time.time()),
+                        model=payload.model,
+                        choices=[
+                            CompletionChunkChoice(
+                                text=token,
+                                index=choice_index,
+                            )
+                        ],
+                    )
+                    yield _sse_payload(chunk)
+                total_completion_tokens += stream.completion_tokens
+                final_chunk = CompletionChunk(
                     id=completion_id,
                     created=int(time.time()),
                     model=payload.model,
                     choices=[
                         CompletionChunkChoice(
-                            text=token,
-                            index=index,
+                            text="",
+                            index=choice_index,
+                            finish_reason=stream.finish_reason,
                         )
                     ],
                 )
-                yield _sse_payload(chunk)
-            total_completion_tokens += stream.completion_tokens
-            final_chunk = CompletionChunk(
-                id=completion_id,
-                created=int(time.time()),
-                model=payload.model,
-                choices=[
-                    CompletionChunkChoice(
-                        text="",
-                        index=index,
-                        finish_reason=stream.finish_reason,
-                    )
-                ],
-            )
-            yield _sse_payload(final_chunk)
+                yield _sse_payload(final_chunk)
+                choice_index += 1
         usage = UsageInfo(
-            prompt_tokens=prompt_tokens or 0,
+            prompt_tokens=aggregated_prompt_tokens,
             completion_tokens=total_completion_tokens,
-            total_tokens=(prompt_tokens or 0) + total_completion_tokens,
+            total_tokens=aggregated_prompt_tokens + total_completion_tokens,
         )
         tail = CompletionChunk(
             id=completion_id,

--- a/app/routers/models.py
+++ b/app/routers/models.py
@@ -3,21 +3,41 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from ..core.model_registry import list_models
+from ..core.errors import model_not_found
+from ..core.model_registry import ModelSpec, get_model_spec, list_models
 
 router = APIRouter(prefix="/v1", tags=["models"])
 
 
+def _serialize_model(spec: ModelSpec) -> dict:
+    payload = {
+        "id": spec.name,
+        "object": "model",
+        "owned_by": "owner",
+        "permission": [],
+    }
+    metadata = spec.metadata.to_dict() if spec.metadata else {"description": "No additional details provided."}
+    metadata.setdefault("huggingface_repo", spec.hf_repo)
+    if spec.max_context_tokens is not None:
+        metadata.setdefault("max_context_tokens", spec.max_context_tokens)
+    if spec.dtype:
+        metadata.setdefault("dtype", spec.dtype)
+    if spec.device:
+        metadata.setdefault("default_device", spec.device)
+    payload["metadata"] = metadata
+    return payload
+
+
 @router.get("/models")
 def list_available_models() -> dict:
-    data = []
-    for spec in list_models():
-        data.append(
-            {
-                "id": spec.name,
-                "object": "model",
-                "owned_by": "owner",
-                "permission": [],
-            }
-        )
+    data = [_serialize_model(spec) for spec in list_models()]
     return {"object": "list", "data": data}
+
+
+@router.get("/models/{model_id}")
+def retrieve_model(model_id: str) -> dict:
+    try:
+        spec = get_model_spec(model_id)
+    except KeyError:
+        raise model_not_found(model_id)
+    return _serialize_model(spec)


### PR DESCRIPTION
## Summary
- handle list prompts in the completions endpoint and update streaming usage accounting for multi-prompt requests
- enrich the built-in model registry with author-sourced metadata and expose it through both list and detail endpoints
- extend the compatibility test suite to cover prompt batching and model metadata serialization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690510db4254832ba4688eb79881bc86