### PR TITLE
Parallelize CI test workflow across environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+name: Run tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Unit tests
+            run_live: "0"
+            command: pytest
+            api_base_url: "https://k050506koch-gpt3-dev-api.hf.space"
+          - name: Live model probe
+            run_live: "1"
+            command: pytest -k live_more_models
+            api_base_url: "https://k050506koch-gpt3-dev-api.hf.space"
+
+    runs-on: ubuntu-latest
+    name: ${{ matrix.name }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
+
+      - name: Run tests
+        env:
+          RUN_LIVE_API_TESTS: ${{ matrix.run_live }}
+          API_BASE_URL: ${{ matrix.api_base_url }}
+        run: ${{ matrix.command }}

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ export RUN_LIVE_API_TESTS=0 #or 1
 ```
 ```bash
 pytest
-pytest -k pytest -k live_more_models
+pytest -k live_more_models
 ```
 
 ## Project Structure

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,9 @@
+fastapi>=0.110.0
+httpx>=0.27.0
+pytest>=7.4.0
+pytest-asyncio>=0.23.0
+pydantic>=2.6.0
+pydantic-settings>=2.1.0
+sse-starlette>=1.6.5
+python-multipart>=0.0.9
+tiktoken>=0.5.2


### PR DESCRIPTION
## Summary
- run the CI workflow as a two-entry matrix so the default and live model suites execute in parallel with their own RUN_LIVE_API_TESTS values
- configure the live test leg to target the hosted Hugging Face deployment so the probes can reach a running API

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69132767843c832ba419be7a0d479730)