### PR TITLE
Allow combining default registry with custom files

### DIFF
--- a/app/core/model_registry.py
+++ b/app/core/model_registry.py
@@ -253,14 +253,16 @@ def _initialize_registry() -> None:
         include_defaults = os.environ.get("PYTEST_CURRENT_TEST") is None
     else:
         include_defaults = bool(raw_include)
+    file_specs: List[ModelSpec] = []
     if registry_path_value:
         registry_path = Path(registry_path_value)
         if registry_path.exists():
-            specs = list(_load_registry_from_file(registry_path))
+            file_specs = list(_load_registry_from_file(registry_path))
         else:
             raise FileNotFoundError(f"MODEL_REGISTRY_PATH not found: {registry_path}")
-    elif include_defaults:
-        specs = list(_DEFAULT_MODELS)
+    if include_defaults:
+        specs.extend(_DEFAULT_MODELS)
+    specs.extend(file_specs)
     allow_list = None
     if settings.model_allow_list:
         allow_list = {name for name in settings.model_allow_list}

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -37,18 +37,37 @@ from app.core import model_registry
 class DummySettings:
     """Minimal settings stand-in for registry tests."""
 
-    def __init__(self, *, allow_list: list[str] | None = None, registry_path: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        allow_list: list[str] | None = None,
+        registry_path: str | None = None,
+        include_defaults: bool | None = None,
+    ) -> None:
         self.model_allow_list = allow_list
         self._registry_path = registry_path
+        self.include_default_models = include_defaults
 
     def model_dump(self) -> dict:
-        return {"model_registry_path": self._registry_path}
+        data = {"model_registry_path": self._registry_path}
+        if self.include_default_models is not None:
+            data["include_default_models"] = self.include_default_models
+        return data
 
 
 @pytest.fixture(autouse=True)
 def reset_registry(monkeypatch):
-    def apply(*, allow_list: list[str] | None = None, registry_path: str | None = None) -> None:
-        dummy = DummySettings(allow_list=allow_list, registry_path=registry_path)
+    def apply(
+        *,
+        allow_list: list[str] | None = None,
+        registry_path: str | None = None,
+        include_defaults: bool | None = None,
+    ) -> None:
+        dummy = DummySettings(
+            allow_list=allow_list,
+            registry_path=registry_path,
+            include_defaults=include_defaults,
+        )
         monkeypatch.setattr(model_registry, "get_settings", lambda: dummy, raising=False)
         model_registry._registry.clear()
 
@@ -85,3 +104,14 @@ def test_model_allow_list_unknown_model(reset_registry):
     reset_registry(allow_list=["unknown"])
     with pytest.raises(KeyError):
         model_registry.list_models()
+
+
+def test_custom_registry_can_extend_defaults(reset_registry, tmp_path: Path):
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps([{"name": "Tiny", "hf_repo": "dummy/tiny"}])
+    )
+    reset_registry(registry_path=str(registry_path), include_defaults=True)
+    names = {spec.name for spec in model_registry.list_models()}
+    assert "Tiny" in names
+    assert "GPT3-dev" in names


### PR DESCRIPTION
## Summary
- make `_initialize_registry` merge the built-in models with entries loaded from `MODEL_REGISTRY_PATH` so custom registries can extend the defaults instead of replacing them
- extend the model registry tests with configurable dummy settings and a new test that exercises the default+custom merge path

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e8e5a084832bab33d3c52c3d643d)