### PR TITLE
Revert to Fail live model probe baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ pinned: false
 
 A production-ready FastAPI server that mirrors the OpenAI REST API surface while proxying requests to Hugging Face causal language models. The service implements the `/v1/completions`, `/v1/models`, and `/v1/embeddings` endpoints with full support for streaming Server-Sent Events (SSE) and OpenAI-style usage accounting. A `/v1/chat/completions` stub is included but currently returns a structured 501 error because the available models are completion-only.
 
-## The API is hosted on HuggingFace Spaces: https://k050506koch-gpt3-dev-api.hf.space
+##The API is hosted on HuggingFace Spaces:
+```bash
+https://k050506koch-gpt3-dev-api.hf.space
+```
 
 ## Features
 

--- a/app/core/model_registry.py
+++ b/app/core/model_registry.py
@@ -59,24 +59,6 @@ class ModelSpec:
 
 _DEFAULT_MODELS: List[ModelSpec] = [
     ModelSpec(
-        name="GPT4-dev-177M-1511",
-        hf_repo="k050506koch/GPT4-dev-177M-1511",
-        dtype="float16",
-        device="auto",
-        max_context_tokens=512,
-        metadata=ModelMetadata(
-            description="117M parameter GPT-4-inspired checkpoint released on 15-11-2025.",
-            parameter_count="117M",
-            training_datasets="HuggingFaceFW/fineweb",
-            training_steps="78,000 steps · sequence length 512 · batch size 192 · Lion optimizer",
-            evaluation="29.30% MMLU (author reported)",
-            notes="Custom GPT-4-insopired architecture that requires trust_remote_code when loading.",
-            sources=(
-                "https://huggingface.co/k050506koch/GPT4-dev-177M-1511",
-            ),
-        ),
-    ),
-    ModelSpec(
         name="GPT3-dev-350m-2805",
         hf_repo="k050506koch/GPT3-dev-350m-2805",
         dtype="float16",


### PR DESCRIPTION
## Summary
- revert the registry-related commits made after "Fail live model probe on API errors," restoring the prior model definitions and tests
- remove the GPT4-dev-177M-1511 spec and README link changes added after that baseline
- keep the model registry tests aligned with the earlier empty-default behavior

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e8e5a084832bab33d3c52c3d643d)